### PR TITLE
fix readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ changed will be recomputed and rerendered making things very fast.
 This module was essentially a merge of [`cache-element`][ce] v2.0.1 with the API of [`nanomorph`][nm]
 before [`cache-element`][ce] switched over to using [`nanomorph`][nm] and essentially had a different purpose.
 There are still ongoing discussions on the future of [`cache-element`][ce].  The idea behind the inheritance
-API is that it provides a handy place to store event handler functions so they don't get redeclaired
+API is that it provides a handy place to store event handler functions so they don't get redeclared
 between render frames like inline functions do.
 
 ## See Also

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ changed will be recomputed and rerendered making things very fast.
 
 `nanomorph`, which saw first use in choo 5, has supported `isSameNode` since it's conception.
 
-### What's the exact difference between cache-element and nanocomponent?
+### What's the exact difference between cache-component and nanocomponent?
 - `cache-component` returns a proxy node if the arguments were the same. If arguments
   change, it'll rerender and return a new node.
 - `nanocomponent` will render a new node initially and always return a proxy node on
@@ -160,7 +160,7 @@ changed will be recomputed and rerendered making things very fast.
 ### Whats the relationship beteen `cache-component` and [`cache-element`][ce]?
 
 This module was essentially a merge of [`cache-element`][ce] v2.0.1 with the API of [`nanomorph`][nm]
-avar [`cache-element`][ce] switched over to using [`nanomorph`][nm] and essentially had a different purpose.
+before [`cache-element`][ce] switched over to using [`nanomorph`][nm] and essentially had a different purpose.
 There are still ongoing discussions on the future of [`cache-element`][ce].  The idea behind the inheritance
 API is that it provides a handy place to store event handler functions so they don't get redeclaired
 between render frames like inline functions do.


### PR DESCRIPTION
fixed an old reference to cache-element, and tried fixing a word (avar?). @bcomnes let me know if that's right, the sentence still sounds a little weird, not sure if that was the right word to replace it with.